### PR TITLE
fix: update aws_region deprecated attribute, improve variable docs, bump provider constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,13 +144,13 @@ Available targets:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.4 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.35 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.4 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.35 |
 
 ## Modules
 
@@ -173,11 +173,11 @@ Available targets:
 |------|-------------|------|---------|:--------:|
 | <a name="input_endpoint_destination_cidr"></a> [endpoint\_destination\_cidr](#input\_endpoint\_destination\_cidr) | Destination CIDR block to route through the AWS Network Firewall endpoints. | `string` | `"0.0.0.0/0"` | no |
 | <a name="input_endpoint_subnet_ids"></a> [endpoint\_subnet\_ids](#input\_endpoint\_subnet\_ids) | List of subnet IDs whose associated route tables should receive a route that targets the AWS Network Firewall VPC endpoint in the same Availability Zone. | `list(string)` | `[]` | no |
-| <a name="input_extra_tags"></a> [extra\_tags](#input\_extra\_tags) | n/a | `map(string)` | `{}` | no |
-| <a name="input_is_hub"></a> [is\_hub](#input\_is\_hub) | Establish this is a HUB or spoke configuration | `bool` | `false` | no |
+| <a name="input_extra_tags"></a> [extra\_tags](#input\_extra\_tags) | Extra tags to add to the resources | `map(string)` | `{}` | no |
+| <a name="input_is_hub"></a> [is\_hub](#input\_is\_hub) | Is this a hub or spoke configuration? | `bool` | `false` | no |
 | <a name="input_nfw_states_list"></a> [nfw\_states\_list](#input\_nfw\_states\_list) | AWS Network Firewall sync states keyed by availability zone, typically sourced from firewall\_status[0].sync\_states. | `any` | `[]` | no |
-| <a name="input_org"></a> [org](#input\_org) | n/a | <pre>object({<br/>    organization_name = string<br/>    organization_unit = string<br/>    environment_type  = string<br/>    environment_name  = string<br/>  })</pre> | n/a | yes |
-| <a name="input_spoke_def"></a> [spoke\_def](#input\_spoke\_def) | n/a | `string` | `"001"` | no |
+| <a name="input_org"></a> [org](#input\_org) | Organization details | <pre>object({<br/>    organization_name = string<br/>    organization_unit = string<br/>    environment_type  = string<br/>    environment_name  = string<br/>  })</pre> | n/a | yes |
+| <a name="input_spoke_def"></a> [spoke\_def](#input\_spoke\_def) | Spoke ID Number, must be a 3 digit number | `string` | `"001"` | no |
 
 ## Outputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,13 +3,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.4 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.35 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.4 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.35 |
 
 ## Modules
 
@@ -32,11 +32,11 @@
 |------|-------------|------|---------|:--------:|
 | <a name="input_endpoint_destination_cidr"></a> [endpoint\_destination\_cidr](#input\_endpoint\_destination\_cidr) | Destination CIDR block to route through the AWS Network Firewall endpoints. | `string` | `"0.0.0.0/0"` | no |
 | <a name="input_endpoint_subnet_ids"></a> [endpoint\_subnet\_ids](#input\_endpoint\_subnet\_ids) | List of subnet IDs whose associated route tables should receive a route that targets the AWS Network Firewall VPC endpoint in the same Availability Zone. | `list(string)` | `[]` | no |
-| <a name="input_extra_tags"></a> [extra\_tags](#input\_extra\_tags) | n/a | `map(string)` | `{}` | no |
-| <a name="input_is_hub"></a> [is\_hub](#input\_is\_hub) | Establish this is a HUB or spoke configuration | `bool` | `false` | no |
+| <a name="input_extra_tags"></a> [extra\_tags](#input\_extra\_tags) | Extra tags to add to the resources | `map(string)` | `{}` | no |
+| <a name="input_is_hub"></a> [is\_hub](#input\_is\_hub) | Is this a hub or spoke configuration? | `bool` | `false` | no |
 | <a name="input_nfw_states_list"></a> [nfw\_states\_list](#input\_nfw\_states\_list) | AWS Network Firewall sync states keyed by availability zone, typically sourced from firewall\_status[0].sync\_states. | `any` | `[]` | no |
-| <a name="input_org"></a> [org](#input\_org) | n/a | <pre>object({<br/>    organization_name = string<br/>    organization_unit = string<br/>    environment_type  = string<br/>    environment_name  = string<br/>  })</pre> | n/a | yes |
-| <a name="input_spoke_def"></a> [spoke\_def](#input\_spoke\_def) | n/a | `string` | `"001"` | no |
+| <a name="input_org"></a> [org](#input\_org) | Organization details | <pre>object({<br/>    organization_name = string<br/>    organization_unit = string<br/>    environment_type  = string<br/>    environment_name  = string<br/>  })</pre> | n/a | yes |
+| <a name="input_spoke_def"></a> [spoke\_def](#input\_spoke\_def) | Spoke ID Number, must be a 3 digit number | `string` | `"001"` | no |
 
 ## Outputs
 

--- a/locals.tf
+++ b/locals.tf
@@ -8,11 +8,10 @@
 #
 
 locals {
-  region_arr        = split("-", data.aws_region.current.id)
+  region_arr        = split("-", data.aws_region.current.region)  # id & name are deprecated from v6.47.0, use region instead
   region            = format("%s%s%s", lower(local.region_arr[0]), lower(substr(local.region_arr[1], 0, 2)), lower(local.region_arr[2]))
   system_name       = format("%s-%s-%s-%s-%s", lower(var.org.organization_unit), lower(var.org.environment_name), lower(var.org.environment_type), var.spoke_def, local.region)
   system_name_short = format("%s-%s-%s-%s-%s", substr(lower(var.org.organization_unit), 0, 3), substr(lower(var.org.environment_name), 0, 3), substr(lower(replace(var.org.environment_type, "-", "")), 0, 4), var.spoke_def, local.region)
   all_tags          = merge(module.tags.locals.common_tags, var.extra_tags)
   secret_store_path = format("/%s/%s/%s", lower(var.org.organization_unit), lower(var.org.environment_name), lower(var.org.environment_type))
-
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,21 +1,37 @@
 ##
-# (c) 2024 - Cloud Ops Works LLC - https://cloudops.works/
-#            On GitHub: https://github.com/cloudopsworks
-#            Distributed Under Apache v2.0 License
+# (c) 2021-2026
+#     Cloud Ops Works LLC - https://cloudops.works/
+#     Find us on:
+#       GitHub: https://github.com/cloudopsworks
+#       WebSite: https://cloudops.works
+#     Distributed Under Apache v2.0 License
 #
 
-# Establish this is a HUB or spoke configuration
+# is_hub: false # (Optional) Is this a hub or spoke configuration? Default: false
 variable "is_hub" {
-  type    = bool
-  default = false
+  description = "Is this a hub or spoke configuration?"
+  type        = bool
+  default     = false
 }
 
+# spoke_def: "001" # (Optional) Spoke ID Number, must be a 3 digit number. Default: "001"
 variable "spoke_def" {
-  type    = string
-  default = "001"
+  description = "Spoke ID Number, must be a 3 digit number"
+  type        = string
+  default     = "001"
+  validation {
+    condition     = (length(var.spoke_def) == 3) && tonumber(var.spoke_def) != null
+    error_message = "The spoke_def must be a 3 digit number as string."
+  }
 }
 
+# org: # (Required) Organization details
+#   organization_name: "example" # (Required) The name of the organization
+#   organization_unit: "devops"  # (Required) The unit within the organization
+#   environment_type: "production" # (Required) The type of environment (e.g. production, staging)
+#   environment_name: "prod"      # (Required) The name of the environment
 variable "org" {
+  description = "Organization details"
   type = object({
     organization_name = string
     organization_unit = string
@@ -24,7 +40,10 @@ variable "org" {
   })
 }
 
+# extra_tags: # (Optional) Extra tags to add to the resources. Default: {}
+#   Tag1: "Value1"
 variable "extra_tags" {
-  type    = map(string)
-  default = {}
+  description = "Extra tags to add to the resources"
+  type        = map(string)
+  default     = {}
 }

--- a/versions.tf
+++ b/versions.tf
@@ -13,7 +13,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.4"
+      version = "~> 6.35"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Replace `data.aws_region.current.id` with `.region` in `locals.tf` — `id` is deprecated from AWS provider v6.47.0
- Update copyright header in `variables.tf` to 2021-2026 format; add descriptions and inline YAML documentation to `is_hub`, `spoke_def`, `org`, `extra_tags`; add validation block for `spoke_def`
- Tighten AWS provider constraint in `versions.tf` from `~> 6.4` to `~> 6.35` to ensure compatibility with the deprecated attribute fix

+semver: fix