### PR TITLE
feat: add NFW and VPC module dependency scaffold support to boilerplate

### DIFF
--- a/.boilerplate/boilerplate.yml
+++ b/.boilerplate/boilerplate.yml
@@ -22,6 +22,41 @@ variables:
     default: {}
     confirm: true
   # End - Generic Boilerplate Variables Setup
+  - name: nfw_dependency_enabled
+    order: 2
+    description: "Enable NFW Module dependency"
+    type: bool
+    default: true
+    confirm: true
+  - name: nfw_dependency_path
+    order: 3
+    description: "Path to NFW Module, required if nfw_dependency_enabled is true"
+    type: string
+    default: "../nfw"
+    confirm: true
+  - name: vpc_dependency_enabled
+    order: 4
+    description: "Enable VPC Module dependency"
+    type: bool
+    default: true
+    confirm: true
+  - name: vpc_dependency_path
+    order: 5
+    description: "Path to VPC Module, required if vpc_dependency_enabled is true"
+    type: string
+    default: "../vpc"
+    confirm: true
+  - name: vpc_dependency_subnets
+    order: 6
+    description: "VPC Subnets scope, required if vpc_dependency_enabled is true, options: intra, private, database, both(database,private), none"
+    type: enum
+    default: intra
+    options:
+      - intra
+      - private
+      - both
+      - none
+    confirm: true
 
 hooks:
   after:

--- a/.boilerplate/terragrunt.hcl
+++ b/.boilerplate/terragrunt.hcl
@@ -23,7 +23,68 @@ locals {
 include "root" {
   path = find_in_parent_folders("{{ .RootFileName }}")
 }
-
+{{ if .vpc_dependency_enabled }}
+dependency "vpc" {
+  config_path = "{{ .vpc_dependency_path }}"
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["validate", "destroy"]
+  mock_outputs = {
+    nat_address = tolist([
+      "2.2.2.2",
+    ])
+    intra_subnets = [
+      "subnet-01234567890123456",
+      "subnet-01234567890123457",
+      "subnet-01234567890123458",
+    ]
+    intra_route_table_ids = [
+      "rtb-1234567890",
+      "rtb-1234567891",
+      "rtb-1234567892",
+    ]
+    vpc_id = "vpc-12345678901234"
+    cloudwatch_log_group = {
+      arn  = "arn:aws:logs:us-east-1:123456789012:log-group:network/hub/hub-000/vpc-12345678901234"
+      name = "network/hub/hub-000/vpc-12345678901234"
+    }
+    vpc_cidr_block = "1.0.0.0/8"
+  }
+}
+{{ end }}
+{{ if .nfw_dependency_enabled }}
+dependency "nfw" {
+  config_path = "{{ .nfw_dependency_path }}"
+  # Configure mock outputs for the `validate` command that are returned when there are no outputs available (e.g the
+  # module hasn't been applied yet.
+  mock_outputs_allowed_terraform_commands = ["validate", "destroy"]
+  mock_outputs = {
+    firewall_arn = "arn:aws:network-firewall:us-east-1:123456789012:firewall/fw-12345678901234"
+    firewall_status = tolist([
+      {
+        "sync_states" = toset([
+          {
+            "attachment" = tolist([
+              {
+                "endpoint_id" = "vpce-12345678901234567"
+                "subnet_id"   = "subnet-01234567890123456"
+              },
+              {
+                "endpoint_id" = "vpce-12345678901234568"
+                "subnet_id"   = "subnet-01234567890123457"
+              },
+              {
+                "endpoint_id" = "vpce-12345678901234569"
+                "subnet_id"   = "subnet-01234567890123458"
+              },
+            ])
+          }
+        ])
+      }
+    ])
+  }
+}
+{{ end}}
 terraform {
   source = "{{ .sourceUrl }}"
 }
@@ -39,7 +100,19 @@ inputs = {
   {{- end }}
   {{- range .optionalVariables }}
   {{- if not (eq .Name "extra_tags" "is_hub" "spoke_def" "org") }}
+  {{- if and $.vpc_dependency_enabled (eq .Name "endpoint_subnet_ids") }}
+  {{- if eq $.vpc_dependency_subnets "both" }}
+  {{ .Name }} = concat(dependency.vpc.outputs.private_subnets, dependency.vpc.outputs.database_subnets)
+  {{- else if eq $.vpc_dependency_subnets "none" }}
+  {{ .Name }} = try(local.local_vars.{{ .Name }}, [])
+  {{- else }}
+  {{ .Name }} = dependency.vpc.outputs.{{ $.vpc_dependency_subnets }}_subnets
+  {{- end }}
+  {{- else if and $.nfw_dependency_enabled (eq .Name "nfw_states_list") }}
+  {{ .Name }} = dependency.nfw.outputs.firewall_status[0].sync_states
+  {{- else }}
   {{ .Name }} = try(local.local_vars.{{ .Name }}, {{ .DefaultValue }})
+  {{- end }}
   {{- end }}
   {{- end }}
   extra_tags = local.tags


### PR DESCRIPTION
## Summary

- Add `nfw_dependency_enabled`/`nfw_dependency_path` and `vpc_dependency_enabled`/`vpc_dependency_path`/`vpc_dependency_subnets` variables to `boilerplate.yml` with confirm prompts; subnet scope accepts enum (intra, private, both, none)
- Add conditional `dependency "vpc"` and `dependency "nfw"` blocks to `terragrunt.hcl` with mock outputs for validate/destroy commands
- Wire `endpoint_subnet_ids` input to the selected VPC subnet output based on scope, and `nfw_states_list` to NFW `firewall_status[0].sync_states`

+semver: patch